### PR TITLE
Let players join a game after a failed attempt

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -464,6 +464,7 @@ Lobby.prototype.show = function (data) {
 				'exFatal': false
 			});
 			swal(data.error, '', 'error');
+			Screen.waitingForResponse = false;
 			return;
 		}
 	} else {


### PR DESCRIPTION
Previously if you failed to join a game for any reason, eg name too short or invalid room code, the join button would silently disable until a refresh.  This was simply due to an un-reset flag, fixed here.