### PR TITLE
Update fabric.js version

### DIFF
--- a/views/layout.pug
+++ b/views/layout.pug
@@ -44,7 +44,7 @@ html
     // Socket.IO
     script(src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.4/socket.io.js')
     // Fabric.js
-    script(src='https://cdnjs.cloudflare.com/ajax/libs/fabric.js/2.3.2/fabric.min.js', integrity='sha256-JQa3Df+83QeB/XVnQYWk9Ns3v4IJ8gnWhgGv1ToHQGg=', crossorigin='anonymous')
+    script(src='https://cdnjs.cloudflare.com/ajax/libs/fabric.js/3.3.2/fabric.min.js', integrity='sha256-tzYSKRkV1Ga9YrVBiNHG44eEQyRcwtNrqOMh2+CTlec=', crossorigin='anonymous')
     // javascript-canvas-to-blob
     script(src='https://cdnjs.cloudflare.com/ajax/libs/javascript-canvas-to-blob/3.3.0/js/canvas-to-blob.min.js')
     // SweetAlert for Bootstrap JS


### PR DESCRIPTION
Love the app! The newer fabric.js allows tablet input and works with more devices. Currently drawing does not work on samsung galaxy tablets or surface touchscreens.