### PR TITLE
Added game setting visibility for non-admins.

### DIFF
--- a/server/app/game.js
+++ b/server/app/game.js
@@ -80,6 +80,10 @@ Game.prototype.removeBotPlayer = function() {
 	}
 };
 
+Game.prototype.sendUpdatedSettings = function(setting) {
+	this.sendToAll("updateSettings", setting);
+}
+
 Game.prototype.initPlayer = function(newPlayer) {
 	//if this is the first user, make them admin
 	if (this.players.length === 0) {
@@ -198,6 +202,7 @@ Game.prototype.sendToAll = function(event, data) {
 	this.players.forEach(function(player) {
 		player.socket.emit(event, {
 			success: true,
+			event: event,
 			gameCode: self.code,
 			player: player.getJson(),
 			data

--- a/server/app/player-ai.js
+++ b/server/app/player-ai.js
@@ -2,7 +2,7 @@ const got = require("got");
 const crypto = require("crypto");
 
 // for shutterstock
-const [username, password] = process.env.SHUTTERSTOCK_API_TOKEN.split(":");
+const [username, password] = ["test","test"]
 
 var Player = require("./player");
 

--- a/server/app/player-ai.js
+++ b/server/app/player-ai.js
@@ -2,7 +2,7 @@ const got = require("got");
 const crypto = require("crypto");
 
 // for shutterstock
-const [username, password] = ["test","test"]
+const [username, password] = process.env.SHUTTERSTOCK_API_TOKEN.split(":");
 
 var Player = require("./player");
 

--- a/server/app/player.js
+++ b/server/app/player.js
@@ -34,6 +34,8 @@ Player.prototype.sendThen = function(event, data, onEvent, next) {
 
 Player.prototype.makeAdmin = function() {
 	this.isAdmin = true;
+	// update lobby (enable settings for new admin)
+	this.socket.emit("adminUpdatedSettings");
 };
 
 module.exports = Player;

--- a/server/routes/socketio.js
+++ b/server/routes/socketio.js
@@ -80,6 +80,14 @@ module.exports = function(app) {
 			}
 		});
 
+		socket.on("adminUpdatedSettings", function(setting) {
+			if (!thisGame || !thisUser) return;
+
+			if (thisUser.isAdmin) {
+				thisGame.sendUpdatedSettings(setting);
+			}
+		})
+
 		socket.on("addBotPlayer", function() {
 			if (!thisGame || !thisUser) return;
 

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -76,18 +76,18 @@ block content
         h5 Game Settings:
         .checkboxes.mb-3
           .custom-control.custom-switch
-            input#lobby-settings-wordfirst.custom-control-input(type='checkbox')
+            input#lobby-settings-wordfirst.custom-control-input.lobby-setting(type='checkbox')
             label.custom-control-label(for='lobby-settings-wordfirst') Players write first word (not recommended for first time)
           .custom-control.custom-switch
-            input#lobby-settings-showNeighbors.custom-control-input(type='checkbox')
+            input#lobby-settings-showNeighbors.custom-control-input.lobby-setting(type='checkbox')
             label.custom-control-label(for='lobby-settings-showNeighbors') Show identity of players you are passing to and from
         label Word pack:
-        select.form-control#lobby-settings-wordpack.mb-2
+        select.form-control.lobby-setting#lobby-settings-wordpack.mb-2
           option(disabled='', selected='') Select a word pack...
           for item in wordpacks
             option #{item}
         label Time limit:
-        select.form-control#lobby-settings-timelimit
+        select.form-control.lobby-setting#lobby-settings-timelimit
           option(disabled='', selected='') Select a drawing time limit...
           option No time limit (recommended)
           option 5 seconds
@@ -96,8 +96,9 @@ block content
           option 30 seconds
           option 45 seconds
           option 1 minute
-        button#lobby-settings-addbot.btn.btn-default.mt-2(type='button') Add Bot Player
-        button#lobby-settings-removebot.btn.btn-default.mt-2(type='button') Remove Bot Player
+        div#lobby-settings-bots.d-none
+          button#lobby-settings-addbot.btn.btn-default.mt-2(type='button') Add Bot Player
+          button#lobby-settings-removebot.btn.btn-default.mt-2(type='button') Remove Bot Player
     br
     .btn-toolbar
       button#lobby-leave.btn.btn-default.btn-lg.mr-2(type='button') Leave Game


### PR DESCRIPTION
Hey there, I play this game pretty every week as a gamenight game for a team I'm on, today I finally decided to check out the code. 
I picked a pretty old issue to figure out how the code work, but I think I've got it working pretty well.
https://github.com/tannerkrewson/drawphone/issues/13

Explanation: 
I made the settings visible for all players, but disabled if you're not the admin. Whenever the admin changes a setting a `adminUpdatedSettings` socket event is sent to the server, then a `updatedSettings` event with the data of how the event was changed. to all players and their view is updated. 

Just cause it annoyed me whenever I saw it I made sure that changing whether or not `First Word` was picked by the players changed the `wordpack` (if it's active then the wordpack will go back to default as it does for the admin), and if an admin leaves the lobby the controls will be enabled for the next admin.

