### PR TITLE
Remove Fake Artist Online

### DIFF
--- a/server/views/moregames.pug
+++ b/server/views/moregames.pug
@@ -25,13 +25,6 @@ block content
       i by Joshua Porter
     p
       b
-        a(href="https://kc-fakeartistonline.herokuapp.com/" target="_blank") Fake Artist Online
-      br
-      | Based on A Fake Artist Goes to New York
-      br
-      i by Gideon Wong
-    p
-      b
         a(href="https://jackboxgames.com/games/" target="_blank") The Jackbox Party Packs
       br
       i by Jackbox Games


### PR DESCRIPTION
Thanks for Drawphone and the list of games!

Fake Artist Online was taken offline at the request of Oink Games, so there's nothing to link to any more. 