### PR TITLE
Ensure draw buttons are still visible after submitting a blank drawing

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -936,6 +936,7 @@ Game.prototype.checkIfDone = function(newLinkType) {
 		if (this.canvas.isBlank) {
 			showElement("#game-drawing");
 			showElement("#game-buttons");
+			showElement("#game-draw-buttons");
 			swal(
 				"Your picture is blank!",
 				"Please draw a picture, then try again.",


### PR DESCRIPTION
This fixes the issue where the color picker and brush size buttons are permanently hidden after submitting a blank drawing.