### PR TITLE
Randomize which player gets which player's drawing/word each round.

### DIFF
--- a/server/app/round.js
+++ b/server/app/round.js
@@ -15,6 +15,43 @@ var WordPacks = require("./words");
 var words = new WordPacks();
 words.loadAll();
 
+// Use each row for a chain. Columns have repetition. For example:
+//   0,4,1,3,2 --> word1
+//   1,0,2,4,3 --> word2
+//   2,1,3,0,4 --> word3
+//   3,2,4,1,0 --> word4
+//   4,3,0,2,1 --> word5
+// If we used columns for the chains, 2 always comes after 1 and before 3.
+function rowCompleteLatinSquare(order) {
+	var diff = [];
+	for (var i = 0; i < order - 1; i++) {
+		diff.push(i + 1);
+	}
+	for (var i = 1; i < order - 1; i += 2) {
+		diff[i] = order - (i + 1);
+	}
+
+	var L = [];
+	for (var i = 0; i < order; i++) {
+		L.push([]);
+		for (var j = 0; j < order; j++) {
+			L[i].push(0);
+		}
+	}
+	for (var j = 0; j < order; j++) {
+		L[j][0] = j;
+	}
+	for (var j = 1; j < order; j++) {
+		for (var i = 0; i < order; i++) {
+			L[i][j] = L[i][j-1] - diff[j-1];
+			if (L[i][j] < 0) {
+				L[i][j] += order;
+			}
+		}
+	}
+	return L;
+}
+
 function Round(
 	number,
 	players,
@@ -30,7 +67,8 @@ function Round(
 	this.showNeighbors = showNeighbors;
 	this.onResults = onResults;
 	this.chains = [];
-	this.chainShuffle = [];
+	this.linkOrder;
+	this.roundNumber = 0;
 	this.disconnectedPlayers = [];
 	this.potentialPlayers = [];
 	this.canViewLastRoundResults = false;
@@ -49,23 +87,6 @@ function Round(
 	this.aiGuessQueue = new AIGuessQueue(() =>
 		words.getRandomWord(this.wordPackName || "Simple words (recommended)")
 	);
-}
-
-Round.prototype.computeChainShuffle = function() {
-	//compute how much to rotate by each round so that each player gets a
-	//   random player every round
-	var totalRotateAmount = [];
-	for (var i = 0; i < this.chains.length; i++) {
-		totalRotateAmount.push(i);
-	}
-	shuffle(totalRotateAmount);
-	for (var i = 0; i < totalRotateAmount.length - 1; i++) {
-		var rotateAmount = totalRotateAmount[i+1] - totalRotateAmount[i];
-		if (rotateAmount < 0) {
-			rotateAmount += totalRotateAmount.length;
-		}
-		this.chainShuffle.push(rotateAmount);
-	}
 }
 
 Round.prototype.start = function() {
@@ -100,7 +121,7 @@ Round.prototype.start = function() {
 	} else {
 		this.sendWordFirstChains();
 	}
-	this.computeChainShuffle();
+	this.linkOrder = rowCompleteLatinSquare(this.chains.length);
 
 	this.startTime = Date.now();
 };
@@ -208,18 +229,15 @@ Round.prototype.nextLinkIfEveryoneIsDone = function() {
 Round.prototype.startNextLink = function() {
 	this.shouldHaveThisManyLinks++;
 
-	//rotate the chains in place
-	//  this is so that players get a chain they have not already had
-	var rotateAmount = this.chainShuffle.shift();
-	for (var i = 0; i < rotateAmount; i++) {
-		this.chains.push(this.chains.shift());
-	}
+	//the first column of linkOrder has the first player in it
+	//  don't send players their own drawings
+        this.roundNumber++;
 
 	//distribute the chains to each player
 	//  players and chains will have the same length
 	var self = this;
 	for (var i = 0; i < this.players.length; i++) {
-		var thisChain = this.chains[i];
+		var thisChain = this.chains[this.linkOrder[i][this.roundNumber]];
 		var thisPlayer = this.players[i];
 
 		thisChain.lastPlayerSentTo = thisPlayer.getJson();

--- a/server/app/round.js
+++ b/server/app/round.js
@@ -52,19 +52,19 @@ function Round(
 }
 
 Round.prototype.computeChainShuffle = function() {
-	//compute how much to rotate by so that each player gets a random
-	//other players entry but never their own
-	var players = [];
+	//compute how much to rotate by each round so that each player gets a
+	//   random player every round
+	var totalRotateAmount = [];
 	for (var i = 0; i < this.chains.length; i++) {
-		players.push(i);
+		totalRotateAmount.push(i);
 	}
-	shuffle(players);
-	for (var i = 0; i < players.length - 1; i++) {
-		var diff = players[i+1] - players[i];
-		if (diff < 0) {
-			diff += players.length;
+	shuffle(totalRotateAmount);
+	for (var i = 0; i < totalRotateAmount.length - 1; i++) {
+		var rotateAmount = totalRotateAmount[i+1] - totalRotateAmount[i];
+		if (rotateAmount < 0) {
+			rotateAmount += totalRotateAmount.length;
 		}
-		this.chainShuffle.push(diff);
+		this.chainShuffle.push(rotateAmount);
 	}
 }
 
@@ -210,7 +210,7 @@ Round.prototype.startNextLink = function() {
 
 	//rotate the chains in place
 	//  this is so that players get a chain they have not already had
-	var rotateAmount = this.chainShuffle.pop();
+	var rotateAmount = this.chainShuffle.shift();
 	for (var i = 0; i < rotateAmount; i++) {
 		this.chains.push(this.chains.shift());
 	}

--- a/server/app/round.js
+++ b/server/app/round.js
@@ -57,8 +57,8 @@ Round.prototype.computeChainShuffle = function() {
 	var players = [];
 	for (var i = 0; i < this.chains.length; i++) {
 		players.push(i);
-        }
-        shuffle(players);
+	}
+	shuffle(players);
 	for (var i = 0; i < players.length - 1; i++) {
 		var diff = players[i+1] - players[i];
 		if (diff < 0) {


### PR DESCRIPTION
Presently, drawphone shuffles the list of players once at the start. Each round, it assigns each player to a chain. The list of chains is rotated once each round, and each player is assigned to the next chain in sequence. The effect is that each player sends their word or picture to the same next player each round of a game.

This PR adds a shuffled ordering of "how many total rotations should the chain list have". Before this PR, the total number of rotations each round is 0, 1, 2, 3, 4, etc. implemented by applying 1 rotation each time we call startNextLink. In this PR take that list of total rotations and randomly shuffle it, then compute the difference in rotations needed to make the total right. So if the shuffle list is [1, 3, 0, 2] then the diff list is 2, 1 (from "-3" with 4 rounds), 2. In startNextLink, we apply the appropriate number of rotations.

In this manner, each player is sending their work to a random player each round, but we still have each player on each chain once.